### PR TITLE
Add trip filter by origin feature

### DIFF
--- a/server/controllers/tripController.js
+++ b/server/controllers/tripController.js
@@ -1,21 +1,21 @@
+import moment from 'moment';
 import TripModel from '../model/tripModel';
 import errorStrings from '../helpers/errorStrings';
 import ResponseHelper from '../helpers/responseHelper';
-
 
 const tripModel = new TripModel('trip');
 const busModel = new TripModel('bus');
 
 /**
 * @fileOverview - class manages all trip logic
-* @class - tripController
+* @class - TripController
 * @requires - ../model/tripsModel
 * @requires - ../helpers/errorStrings
 * @requires - ../helpers/responseHelper
-* @exports - usersController.js
+* @exports - TripController
 * */
 
-class UsersController {
+class TripController {
   /**
  * Create a trip (for admin only)
  * @param {object} req
@@ -36,6 +36,8 @@ class UsersController {
       if (!newTrip) {
         throw new Error(errorStrings.serverError);
       }
+      newTrip.created_on = moment(newTrip.created_on).format('llll');
+      newTrip.trip_date = moment(newTrip.trip_date).format('llll');
       return ResponseHelper.success(res, 201, newTrip);
     } catch (error) {
       return ResponseHelper.error(res, 500, errorStrings.serverError);
@@ -51,7 +53,13 @@ class UsersController {
 
   static async getTrips(req, res) {
     try {
-      const trips = await tripModel.getTrips();
+      let trips = [];
+      const { filter_by } = req.query;
+      if (filter_by) {
+        trips = await tripModel.getFilteredTrips(filter_by, req.body.filter_value);
+        return ResponseHelper.success(res, 200, trips);
+      }
+      trips = await tripModel.getTrips();
       return ResponseHelper.success(res, 200, trips);
     } catch (error) {
       return ResponseHelper.error(res, 500, errorStrings.serverError);
@@ -86,4 +94,4 @@ class UsersController {
   }
 }
 
-export default UsersController;
+export default TripController;

--- a/server/helpers/errorStrings.js
+++ b/server/helpers/errorStrings.js
@@ -24,6 +24,7 @@ const errorStrings = {
   alreadyCancelled: 'Trip already cancelled',
   noTrip: 'Trip not found',
   validtripId: 'Enter a valid trip id',
+  validFilterValue: 'filter_value is not allowed to be empty',
 
   notAllowed: 'You are forbidden from accessing this section of the app',
   sessionExpired: 'Session expired, login again',

--- a/server/middleware/validateTrip.js
+++ b/server/middleware/validateTrip.js
@@ -24,16 +24,45 @@ class ValidateTrip {
    * @callback {Function} next
    * @return {Object} error
    */
-  static createTripForm(request, response, next) {
+  static validateCreateTrip(request, response, next) {
     const createTripSchema = Joi.object().keys({
       bus_id: validId.error(new Error(errorStrings.validBusId)),
       origin: Joi.string().required(),
       destination: Joi.string().required(),
-      trip_date: Joi.date().iso().required(),
+      trip_date: Joi.date().iso().greater(new Date().toLocaleString()).required(),
       fare: Joi.number().precision(2).required(),
     });
 
     const error = Validator.validateJoi(request.body, createTripSchema);
+    if (!error) {
+      return next();
+    }
+    return responseHelper.error(response, 422, error);
+  }
+
+  /**
+ * validate get trip query
+ * @param {Object} request
+ * @param {Object} response
+ * @callback {Function} next
+ * @return {Object} error
+ */
+  static validateGetTrip(request, response, next) {
+    const { filter_by } = request.query;
+    if (!filter_by) {
+      return next();
+    }
+    if (filter_by !== 'origin') {
+      return responseHelper.error(response, 404, errorStrings.pageNotFound);
+    }
+    const data = {
+      filter_value: request.body.filter_value,
+    };
+    const getTripSchema = Joi.object().keys({
+      filter_value: Joi.string().required(),
+    });
+
+    const error = Validator.validateJoi(data, getTripSchema);
     if (!error) {
       return next();
     }
@@ -47,7 +76,7 @@ class ValidateTrip {
  * @callback {Function} next
  * @return {Object} error
  */
-  static cancelTripParam(request, response, next) {
+  static validateCancelTrip(request, response, next) {
     const cancelTripSchema = Joi.object().keys({
       tripId: validId.error(new Error(errorStrings.validtripId)),
     });

--- a/server/model/db/migrations.db.js
+++ b/server/model/db/migrations.db.js
@@ -7,7 +7,8 @@ pool.query(`DROP TABLE IF EXISTS users CASCADE;
     first_name VARCHAR(128),
     last_name VARCHAR(128),
     password VARCHAR NOT NULL,
-    is_admin BOOLEAN NOT NULL DEFAULT false
+    is_admin BOOLEAN NOT NULL DEFAULT false,
+    registered_on TIMESTAMP NOT NULL DEFAULT NOW()
   );
   DROP TABLE IF EXISTS bus CASCADE;
   CREATE TABLE bus(
@@ -16,7 +17,8 @@ pool.query(`DROP TABLE IF EXISTS users CASCADE;
     manufacturer VARCHAR(100) NOT NULL,
     model VARCHAR(100) NOT NULL,
     year VARCHAR(6) NOT NULL,
-    capacity SMALLINT NOT NULL
+    capacity SMALLINT NOT NULL,
+    created_on TIMESTAMP NOT NULL DEFAULT NOW()
   );
   DROP TABLE IF EXISTS trip CASCADE;
   CREATE TABLE trip(
@@ -24,7 +26,8 @@ pool.query(`DROP TABLE IF EXISTS users CASCADE;
     bus_id UUID NOT NULL,
     origin VARCHAR(100) NOT NULL,
     destination VARCHAR(100) NOT NULL,
-    trip_date VARCHAR(100) NOT NULL,
+    trip_date TIMESTAMP NOT NULL,
+    created_on TIMESTAMP NOT NULL DEFAULT NOW(),
     fare NUMERIC(10, 2) NOT NULL,
     status VARCHAR(10) NOT NULL DEFAULT 'active'
   );

--- a/server/model/db/seed.db.js
+++ b/server/model/db/seed.db.js
@@ -25,10 +25,10 @@ INSERT INTO bus (
 INSERT INTO trip (
   id, bus_id, origin, destination, trip_date, fare, status
 ) VALUES
-('aaac8272-4b57-423c-906f-3da93e823f49', '1232d3d7-9c27-4a3e-bcd0-b1ecf914e123', 'Ikeja, Lagos', 'CMS, Lagos', '2019-04-02', 500.00, 'active'),
-('bbbc8272-4b57-423c-906f-3da93e823f49', '1232d3d7-9c27-4a3e-bcd0-b1ecf914e123', 'Alausa, Lagos', 'Maryland, Lagos', '2019-06-26', 300.00, 'cancelled'),
-('ccc58272-4b57-423c-906f-3da93e823f49', '2222d3d7-9c27-4a3e-bcd0-b1ecf914e222', 'Garki, Abuja', 'Hilton Drive, Abuja', '2019-05-30', 1000.00, 'active'),
-('dddc8272-4b57-423c-906f-3da93e823f49', '1232d3d7-9c27-4a3e-bcd0-b1ecf914e123', 'Ikoyi, Lagos', 'Victoria Island, Lagos', '2019-01-20', 600.00, 'active');
+('aaac8272-4b57-423c-906f-3da93e823f49', '1232d3d7-9c27-4a3e-bcd0-b1ecf914e123', 'Ikeja, Lagos', 'CMS, Lagos', '2019-09-02T03:32:45.678Z', 500.00, 'active'),
+('bbbc8272-4b57-423c-906f-3da93e823f49', '1232d3d7-9c27-4a3e-bcd0-b1ecf914e123', 'Alausa, Lagos', 'Maryland, Lagos', '2019-03-10T03:32:45.678Z', 300.00, 'cancelled'),
+('ccc58272-4b57-423c-906f-3da93e823f49', '1232d3d7-9c27-4a3e-bcd0-b1ecf914e123', 'Garki, Abuja', 'Hilton Drive, Abuja', '2019-10-24T03:32:45.678Z', 1000.00, 'active'),
+('dddc8272-4b57-423c-906f-3da93e823f49', '1232d3d7-9c27-4a3e-bcd0-b1ecf914e123', 'Ikoyi, Lagos', 'Victoria Island, Lagos', '2019-11-24T03:32:45.678Z', 600.00, 'active');
 INSERT INTO booking (
   id, trip_id, user_id, seat_number
 ) VALUES

--- a/server/model/tripModel.js
+++ b/server/model/tripModel.js
@@ -1,7 +1,5 @@
 import uuid from 'uuid';
-import moment from 'moment';
 import Model from './model';
-
 
 /**
 * @fileOverview - class manages all trip data storage
@@ -22,12 +20,11 @@ class TripModel extends Model {
     bus_id, origin, destination, trip_date, fare,
   }) {
     try {
-      const formatted_date = moment(trip_date).format('llll');
       const id = uuid();
       const { rows } = await this.insert(
         'id, bus_id, origin, destination, trip_date, fare', '$1, $2, $3, $4, $5, $6',
         [
-          id, bus_id, origin, destination, formatted_date, fare,
+          id, bus_id, origin, destination, trip_date, fare,
         ],
       );
       return rows[0];
@@ -44,6 +41,20 @@ class TripModel extends Model {
   async getTrips() {
     try {
       const { rows } = await this.select('*');
+      return rows;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
+     * Get filtered trips
+     * @returns {object} an object with all trips
+     */
+
+  async getFilteredTrips(filter_by, filter_value) {
+    try {
+      const { rows } = await this.selectWhere('*', `LOWER(${filter_by}) LIKE LOWER('%${filter_value}%')`);
       return rows;
     } catch (error) {
       throw error;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -21,9 +21,10 @@ const routes = (app) => {
   const api = '/api/v1';
   app.post(`${api}/auth/signup`, ValidateUser.validateSignupFormData, UsersController.signup);
   app.post(`${api}/auth/signin`, ValidateUser.validateSigninFormData, UsersController.signin);
-  app.post(`${api}/trips`, Auth.authenticateAdmin, ValidateTrip.createTripForm, TripController.createTrip);
-  app.get(`${api}/trips`, Auth.authenticateUser, TripController.getTrips);
-  app.patch(`${api}/trips/:tripId`, Auth.authenticateAdmin, ValidateTrip.cancelTripParam, TripController.cancelTrip);
+  app.post(`${api}/trips`, Auth.authenticateAdmin, ValidateTrip.validateCreateTrip, TripController.createTrip);
+  app.get(`${api}/trips`, Auth.authenticateUser, ValidateTrip.validateGetTrip, TripController.getTrips);
+  app.get(`${api}/trips?filter_by=origin`, Auth.authenticateUser, ValidateTrip.validateGetTrip, TripController.getTrips);
+  app.patch(`${api}/trips/:tripId`, Auth.authenticateAdmin, ValidateTrip.validateCancelTrip, TripController.cancelTrip);
   app.get('/', (req, res) => ResponseHelper.success(res, 200, { message: 'Welcome to Way Farer' }));
   // invalid url
   app.all('*', (req, res) => ResponseHelper.error(res, 404, errorStrings.pageNotFound));

--- a/server/tests/testData.js
+++ b/server/tests/testData.js
@@ -8,35 +8,35 @@ const trip = [
     bus_id: '8502d3d7-9c27-4a3e-bcd0-b1ecf914e628', // valid trip details
     origin: 'Ikotun, Lagos',
     destination: 'Ikeja, Lagos',
-    trip_date: '2019-06-27T12:23',
+    trip_date: new Date(Date.now() + 86900),
     fare: 750,
   },
   { // element 1
     bus_id: '8502d3d7-9c27-4a3e-bcd0-b1ecf914e628-6655', // invalid bus_id
     origin: 'Ikotun, Lagos',
     destination: 'Ikeja, Lagos',
-    trip_date: '2019-06-27T12:23',
+    trip_date: new Date(Date.now() + 86900),
     fare: 750,
   },
   { // element 2
     bus_id: '8502d3d7-9c27-4a3e-bcd0-b1ecf914e628',
     origin: '', // empty origin
     destination: 'Ikeja, Lagos',
-    trip_date: '2019-06-27T12:23',
+    trip_date: new Date(Date.now() + 86900),
     fare: 750,
   },
   { // element 3
     bus_id: '8502d3d7-9c27-4a3e-bcd0-b1ecf914e628',
     origin: 'Ikeja, Lagos',
     destination: '', // empty destination
-    trip_date: '2019-06-27T12:23',
+    trip_date: new Date(Date.now() + 86900),
     fare: 750,
   },
   { // element 4
     bus_id: '8502d3d7-9c27-4a3e-bcd0-b1ecf914e628',
     origin: 'Ikotun, Lagos',
     destination: 'Ikeja, Lagos',
-    trip_date: '2019-06-27T12:23-33', // invalid date
+    trip_date: '2020-06-27T12:23-33', // invalid date
     fare: 750,
   },
   { // element 5
@@ -50,30 +50,37 @@ const trip = [
     bus_id: '8502d3d7-9c27-4a3e-bcd0-b1ecf914e628',
     origin: 'Ikotun, Lagos',
     destination: 'Ikeja, Lagos',
-    trip_date: '2019-06-27T12:23',
+    trip_date: new Date(Date.now() + 86900),
     fare: 'fr4', // invalid fare
   },
   { // element 7
     bus_id: '8502d3d7-9c27-4a3e-bcd0-b1ecf914e628',
     origin: 'Ikotun, Lagos',
     destination: 'Ikeja, Lagos',
-    trip_date: '2019-06-27T12:23',
+    trip_date: new Date(Date.now() + 86900),
     fare: '', // empty fare
   },
   { // element 8
     bus_id: '1232d3d7-9c27-4a3e-bcd0-b1ecf914e123', // bus is already assigned to a trip
     origin: 'Ikotun, Lagos',
     destination: 'Ikeja, Lagos',
-    trip_date: '2019-06-27T12:23',
+    trip_date: new Date(Date.now() + 86900),
     fare: 750,
   },
   { // element 9
     bus_id: '1232d3d7-9c27-4a3e-bcd0-b1ecf914e173', // bus is already assigned to a trip
     origin: 'Ikotun, Lagos',
     destination: 'Ikeja, Lagos',
-    trip_date: '2019-06-27T12:23',
+    trip_date: new Date(Date.now() + 86900),
     fare: 750,
   },
+  { // element 10
+    bus_id: '8502d3d7-9c27-4a3e-bcd0-b1ecf914e628',
+    origin: 'Ikotun, Lagos',
+    destination: 'Ikeja, Lagos',
+    trip_date: new Date(Date.now() - 86900), // trip date is in the past 2020-01-27T12:23
+    fare: 750,
+  }, // 2020-01-27T12:23
 ];
 
 export default {

--- a/server/tests/tripTest.js
+++ b/server/tests/tripTest.js
@@ -199,11 +199,24 @@ describe('TRIP CONTROLLER', () => {
             done();
           });
       });
+
+      it('it should not create a trip if trip_date is in the past', (done) => {
+        chai.request(app)
+          .post(tripUrl)
+          .send(testData.trip[10])
+          .set('Authorization', currentToken)
+          .end((error, res) => {
+            expect(res).to.have.status(422);
+            expect(res.body).to.be.a('object');
+            expect(res.body).to.have.property('error');
+            done();
+          });
+      });
     });
   });
 
 
-  describe('GET ALL TRIPS', () => {
+  describe('GET TRIPS', () => {
     it('it should return authentication error', (done) => {
       chai.request(app)
         .get(tripUrl)
@@ -269,6 +282,69 @@ describe('TRIP CONTROLLER', () => {
             expect(res.body.data[0]).to.have.property('trip_date');
             expect(res.body.data[0]).to.have.property('fare');
             expect(res.body.data[0]).to.have.property('status');
+            done();
+          });
+      });
+
+      it('It should get all filtered trips', (done) => {
+        chai.request(app)
+          .get(`${tripUrl}?filter_by=origin`)
+          .set('Authorization', currentToken)
+          .send({ filter_value: 'Lagos' })
+          .end((error, res) => {
+            expect(res).to.have.status(200);
+            expect(res.body).to.be.a('object');
+            expect(res.body).to.have.property('data');
+            expect(res.body.data).to.be.a('array');
+            expect(res.body.data[0]).to.be.a('object');
+            expect(res.body.data[0]).to.have.property('id');
+            expect(res.body.data[0]).to.have.property('bus_id');
+            expect(res.body.data[0]).to.have.property('origin');
+            expect(res.body.data[0]).to.have.property('destination');
+            expect(res.body.data[0]).to.have.property('trip_date');
+            expect(res.body.data[0]).to.have.property('fare');
+            expect(res.body.data[0]).to.have.property('status');
+            done();
+          });
+      });
+      it('it should return empty data if query not matched any row', (done) => {
+        chai.request(app)
+          .get(`${tripUrl}?filter_by=origin`)
+          .set('Authorization', currentToken)
+          .send({ filter_value: 'Maiduguri' })
+          .end((error, res) => {
+            expect(res).to.have.status(200);
+            expect(res.body).to.be.a('object');
+            expect(res.body).to.have.property('status');
+            expect(res.body.status).to.equal('success');
+            expect(res.body).to.have.property('data');
+            expect(res.body.data).to.eql([]);
+            done();
+          });
+      });
+      it('it should not get trips if url is not a valid query', (done) => {
+        chai.request(app)
+          .get(`${tripUrl}?filter_by=original`)
+          .set('Authorization', currentToken)
+          .send({ filter_value: 'Maiduguri' })
+          .end((error, res) => {
+            expect(res).to.have.status(404);
+            expect(res.body).to.be.an('object');
+            expect(res.body).to.have.property('error');
+            expect(res.body.error).to.equal(errorStrings.pageNotFound);
+            done();
+          });
+      });
+      it('it should not get filtered trips with empty filter value', (done) => {
+        chai.request(app)
+          .get(`${tripUrl}?filter_by=origin`)
+          .set('Authorization', currentToken)
+          .send({ filter_value: '' })
+          .end((error, res) => {
+            expect(res).to.have.status(422);
+            expect(res.body).to.be.a('object');
+            expect(res.body).to.have.property('error');
+            expect(res.body.error).to.equal(errorStrings.validFilterValue);
             done();
           });
       });


### PR DESCRIPTION
Users and admin can filter trips by origin calling the
GET /trips?filter_by=origin endpoint
Note that the request body must have paremeter filter_value
which should have the origin
to match from database