### PR TITLE
Add trip filter by destination feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # way-farer
 
 [![Build Status](https://travis-ci.com/shonubijerry/way-farer.svg?branch=develop)](https://travis-ci.com/shonubijerry/way-farer)
-[![Coverage Status](https://coveralls.io/repos/github/shonubijerry/way-farer/badge.svg?branch=develop)](https://coveralls.io/github/shonubijerry/way-farer?branch=develop)
-[![Maintainability](https://api.codeclimate.com/v1/badges/7868b6f9a95ab5b862bd/maintainability)](https://codeclimate.com/github/shonubijerry/way-farer/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/7868b6f9a95ab5b862bd/test_coverage)](https://codeclimate.com/github/shonubijerry/way-farer/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/7868b6f9a95ab5b862bd/maintainability)](https://codeclimate.com/github/shonubijerry/way-farer/maintainability)
+[![Coverage Status](https://coveralls.io/repos/github/shonubijerry/way-farer/badge.svg?branch=develop)](https://coveralls.io/github/shonubijerry/way-farer?branch=develop)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 
 WayFarer is a public bus transportation booking server.
 
 ## Pivotal Tracker Project
+https://www.pivotaltracker.com/n/projects/2358463
 
 ## Server side hosted on Heroku
 
@@ -79,16 +80,16 @@ e.g npm test
 
 <tr><td>GET</td> <td>/api/v1/trips</td>  <td>View all trips</td></tr>
 
-<tr><td>GET</td> <td>/api/v1/trips?origin=:origin</td>  <td>View trips by origin</td></tr>
+<tr><td>GET</td> <td>/api/v1/trips?filter_by=origin</td>  <td>View trips by origin</td></tr>
 
-<tr><td>GET</td> <td>/api/v1/trips?destination=:destination</td>  <td>View trips by destination</td></tr>
+<tr><td>GET</td> <td>/api/v1/trips?filter_by=destination</td>  <td>View trips by destination</td></tr>
 
 <tr><td>GET</td> <td>/api/v1/bookings</td>  <td>View all bookings</td></tr>
 
+<tr><td>PATCH</td> <td>/api/v1/trips/:tripId</td>  <td>Cancel a trip</td></tr>
+
 <tr><td>DELETE</td> <td>/api/v1/bookings/:bookingId</td>  <td>Delete a booking</td></tr>
 
-<tr><td>PATCH</td> <td>/api/v1/trips/:tripId</td>  <td>Cancel a trip</td></tr>
- 
 </table>
 
 

--- a/server/middleware/validateTrip.js
+++ b/server/middleware/validateTrip.js
@@ -52,7 +52,7 @@ class ValidateTrip {
     if (!filter_by) {
       return next();
     }
-    if (filter_by !== 'origin') {
+    if (filter_by !== 'origin' && filter_by !== 'destination') {
       return responseHelper.error(response, 404, errorStrings.pageNotFound);
     }
     const data = {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -24,6 +24,7 @@ const routes = (app) => {
   app.post(`${api}/trips`, Auth.authenticateAdmin, ValidateTrip.validateCreateTrip, TripController.createTrip);
   app.get(`${api}/trips`, Auth.authenticateUser, ValidateTrip.validateGetTrip, TripController.getTrips);
   app.get(`${api}/trips?filter_by=origin`, Auth.authenticateUser, ValidateTrip.validateGetTrip, TripController.getTrips);
+  app.get(`${api}/trips?filter_by=destination`, Auth.authenticateUser, ValidateTrip.validateGetTrip, TripController.getTrips);
   app.patch(`${api}/trips/:tripId`, Auth.authenticateAdmin, ValidateTrip.validateCancelTrip, TripController.cancelTrip);
   app.get('/', (req, res) => ResponseHelper.success(res, 200, { message: 'Welcome to Way Farer' }));
   // invalid url

--- a/server/tests/tripTest.js
+++ b/server/tests/tripTest.js
@@ -286,11 +286,33 @@ describe('TRIP CONTROLLER', () => {
           });
       });
 
-      it('It should get all filtered trips', (done) => {
+      it('It should get all filtered trips by origin', (done) => {
         chai.request(app)
           .get(`${tripUrl}?filter_by=origin`)
           .set('Authorization', currentToken)
           .send({ filter_value: 'Lagos' })
+          .end((error, res) => {
+            expect(res).to.have.status(200);
+            expect(res.body).to.be.a('object');
+            expect(res.body).to.have.property('data');
+            expect(res.body.data).to.be.a('array');
+            expect(res.body.data[0]).to.be.a('object');
+            expect(res.body.data[0]).to.have.property('id');
+            expect(res.body.data[0]).to.have.property('bus_id');
+            expect(res.body.data[0]).to.have.property('origin');
+            expect(res.body.data[0]).to.have.property('destination');
+            expect(res.body.data[0]).to.have.property('trip_date');
+            expect(res.body.data[0]).to.have.property('fare');
+            expect(res.body.data[0]).to.have.property('status');
+            done();
+          });
+      });
+
+      it('It should get all filtered trips by destination', (done) => {
+        chai.request(app)
+          .get(`${tripUrl}?filter_by=destination`)
+          .set('Authorization', currentToken)
+          .send({ filter_value: 'Abuja' })
           .end((error, res) => {
             expect(res).to.have.status(200);
             expect(res.body).to.be.a('object');


### PR DESCRIPTION
Users and admin can filter trips by destination calling the
GET /trips?filter_by=destination endpoint
Note that the request body must have paremeter filter_value
which should have the destination to match from database