### PR TITLE
[#167105043] Seat number cannot exceed bus capacity

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -19,7 +19,7 @@ checks:
       threshold: 20
   method-lines:
     config:
-      threshold: 30
+      threshold: 35
   nested-control-flow:
     config:
       threshold: 4

--- a/server/controllers/bookingController.js
+++ b/server/controllers/bookingController.js
@@ -35,15 +35,19 @@ class BookingController {
         return ResponseHelper.error(res, 404, errorStrings.tripNotFound);
       }
       if (tripInfo.status === 'cancelled') {
-        return ResponseHelper.error(res, 409, errorStrings.cancelledTrip);
+        return ResponseHelper.error(res, 422, errorStrings.cancelledTrip);
+      }
+      if (seat_number > tripInfo.capacity) {
+        const errorMessage = `Seat number ${seat_number} exceeds bus capacity of ${tripInfo.capacity}. ${errorStrings.availableSeatsAPI}`;
+        return ResponseHelper.error(res, 406, errorMessage);
       }
       const isPastTrip = moment().isAfter(moment(tripInfo.trip_date, 'llll'));
       if (isPastTrip) {
-        return ResponseHelper.error(res, 409, errorStrings.pastTrip);
+        return ResponseHelper.error(res, 422, errorStrings.pastTrip);
       }
       const isTaken = await BookingController.checkSeatAvailablity(trip_id, seat_number);
       if (isTaken) {
-        const errorMessage = `Seat number ${seat_number} is booked. Check available seats with GET /bookings/:tripId/availableSeats`;
+        const errorMessage = `Seat number ${seat_number} is booked. ${errorStrings.availableSeatsAPI}`;
         return ResponseHelper.error(res, 409, errorMessage);
       }
       const created_on = moment().format('llll');

--- a/server/helpers/errorStrings.js
+++ b/server/helpers/errorStrings.js
@@ -30,6 +30,7 @@ const errorStrings = {
   validBookingId: 'Enter a valid booking id',
   bookingNotFound: 'Booking not found',
   invalidSeatNumber: 'seat_number must be a number',
+  availableSeatsAPI: 'Check available seats with GET /bookings/:tripId/availableSeats',
 
   notAllowed: 'You are forbidden from accessing this section of the app',
   sessionExpired: 'Session expired, login again',

--- a/server/middleware/ValidateUser.js
+++ b/server/middleware/ValidateUser.js
@@ -39,7 +39,7 @@ class ValidateUser {
     if (!error) {
       return next();
     }
-    return responseHelper.error(response, 422, error);
+    return responseHelper.error(response, 400, error);
   }
 
   /**
@@ -63,7 +63,7 @@ class ValidateUser {
     if (!error) {
       return next();
     }
-    return responseHelper.error(response, 422, error);
+    return responseHelper.error(response, 400, error);
   }
 }
 

--- a/server/middleware/validateBooking.js
+++ b/server/middleware/validateBooking.js
@@ -27,14 +27,14 @@ class ValidateBooking {
   static validateCreateBooking(request, response, next) {
     const createBookingSchema = Joi.object().keys({
       trip_id: validId.error(new Error(errorStrings.validTripId)),
-      seat_number: Joi.number().required(),
+      seat_number: Joi.number().min(1).required(),
     });
 
     const error = Validator.validateJoi(request.body, createBookingSchema);
     if (!error) {
       return next();
     }
-    return responseHelper.error(response, 422, error);
+    return responseHelper.error(response, 400, error);
   }
 
   /**
@@ -53,7 +53,7 @@ class ValidateBooking {
     if (!error) {
       return next();
     }
-    return responseHelper.error(response, 422, error);
+    return responseHelper.error(response, 400, error);
   }
 
   /**
@@ -72,7 +72,7 @@ class ValidateBooking {
     if (!error) {
       return next();
     }
-    return responseHelper.error(response, 422, error);
+    return responseHelper.error(response, 400, error);
   }
 }
 

--- a/server/middleware/validateTrip.js
+++ b/server/middleware/validateTrip.js
@@ -37,7 +37,7 @@ class ValidateTrip {
     if (!error) {
       return next();
     }
-    return responseHelper.error(response, 422, error);
+    return responseHelper.error(response, 400, error);
   }
 
   /**
@@ -66,7 +66,7 @@ class ValidateTrip {
     if (!error) {
       return next();
     }
-    return responseHelper.error(response, 422, error);
+    return responseHelper.error(response, 400, error);
   }
 
   /**
@@ -85,7 +85,7 @@ class ValidateTrip {
     if (!error) {
       return next();
     }
-    return responseHelper.error(response, 422, error);
+    return responseHelper.error(response, 400, error);
   }
 }
 

--- a/server/tests/bookingTest.js
+++ b/server/tests/bookingTest.js
@@ -72,7 +72,7 @@ describe('BOOKING CONTROLLER', () => {
         .send({ trip_id, seat_number })
         .set('Authorization', currentToken)
         .end((error, res) => {
-          expect(res).to.have.status(422);
+          expect(res).to.have.status(400);
           expect(res.body).to.be.a('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.validTripId);
@@ -88,7 +88,7 @@ describe('BOOKING CONTROLLER', () => {
         .send({ trip_id, seat_number })
         .set('Authorization', currentToken)
         .end((error, res) => {
-          expect(res).to.have.status(422);
+          expect(res).to.have.status(400);
           expect(res.body).to.be.a('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.validTripId);
@@ -104,7 +104,7 @@ describe('BOOKING CONTROLLER', () => {
         .send({ trip_id, seat_number })
         .set('Authorization', currentToken)
         .end((error, res) => {
-          expect(res).to.have.status(422);
+          expect(res).to.have.status(400);
           expect(res.body).to.be.a('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.invalidSeatNumber);
@@ -120,7 +120,7 @@ describe('BOOKING CONTROLLER', () => {
         .send({ trip_id, seat_number })
         .set('Authorization', currentToken)
         .end((error, res) => {
-          expect(res).to.have.status(422);
+          expect(res).to.have.status(400);
           expect(res.body).to.be.a('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.invalidSeatNumber);
@@ -152,7 +152,7 @@ describe('BOOKING CONTROLLER', () => {
         .send({ trip_id, seat_number })
         .set('Authorization', currentToken)
         .end((error, res) => {
-          expect(res).to.have.status(409);
+          expect(res).to.have.status(422);
           expect(res.body).to.be.a('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.cancelledTrip);
@@ -176,6 +176,38 @@ describe('BOOKING CONTROLLER', () => {
         });
     });
 
+    it('it should not create a booking if seat number exceeds bus capacity', (done) => {
+      const trip_id = 'ccc58272-4b57-423c-906f-3da93e823f49'; // active trip
+      const seat_number = 54; // seat number is greater than bus capacity
+      chai.request(app)
+        .post(bookingUrl)
+        .send({ trip_id, seat_number })
+        .set('Authorization', currentToken)
+        .end((error, res) => {
+          expect(res).to.have.status(406);
+          expect(res.body).to.be.a('object');
+          expect(res.body).to.have.property('error');
+          expect(res.body.error).to.equal('Seat number 54 exceeds bus capacity of 30. Check available seats with GET /bookings/:tripId/availableSeats');
+          done();
+        });
+    });
+
+    it('it should not create a booking if seat number is less than 1', (done) => {
+      const trip_id = 'ccc58272-4b57-423c-906f-3da93e823f49'; // active trip
+      const seat_number = -4; // seat number is less than 1
+      chai.request(app)
+        .post(bookingUrl)
+        .send({ trip_id, seat_number })
+        .set('Authorization', currentToken)
+        .end((error, res) => {
+          expect(res).to.have.status(400);
+          expect(res.body).to.be.a('object');
+          expect(res.body).to.have.property('error');
+          expect(res.body.error).to.equal('seat_number must be larger than or equal to 1');
+          done();
+        });
+    });
+
     it('it should not create a booking for a past trip', (done) => {
       const trip_id = 'dddc8272-4b57-423c-906f-3da93e823f49'; // past trip
       const seat_number = 17; // available seat number
@@ -184,7 +216,7 @@ describe('BOOKING CONTROLLER', () => {
         .send({ trip_id, seat_number })
         .set('Authorization', currentToken)
         .end((error, res) => {
-          expect(res).to.have.status(409);
+          expect(res).to.have.status(422);
           expect(res.body).to.be.a('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.pastTrip);
@@ -306,7 +338,7 @@ describe('BOOKING CONTROLLER', () => {
           .delete(`${bookingUrl}/23368272-4b57-423c-906f-3da93e823f63-4etys`)
           .set('Authorization', currentToken)
           .end((error, res) => {
-            expect(res).to.have.status(422);
+            expect(res).to.have.status(400);
             expect(res.body).to.be.a('object');
             expect(res.body).to.have.property('error');
             expect(res.body.error).to.equal(errorStrings.validBookingId);
@@ -389,7 +421,7 @@ describe('BOOKING CONTROLLER', () => {
           .get(`${bookingUrl}/aaac8272-4b57-423c-906f-3da93e823f49-77763y/availableSeats`)
           .set('Authorization', currentToken)
           .end((error, res) => {
-            expect(res).to.have.status(422);
+            expect(res).to.have.status(400);
             expect(res.body).to.be.a('object');
             expect(res.body).to.have.property('error');
             expect(res.body.error).to.equal(errorStrings.validTripId);

--- a/server/tests/tripTest.js
+++ b/server/tests/tripTest.js
@@ -94,7 +94,7 @@ describe('TRIP CONTROLLER', () => {
           .send(testData.trip[1])
           .set('Authorization', currentToken)
           .end((error, res) => {
-            expect(res).to.have.status(422);
+            expect(res).to.have.status(400);
             expect(res.body).to.be.a('object');
             expect(res.body).to.have.property('error');
             expect(res.body.error).to.equal(errorStrings.validBusId);
@@ -108,7 +108,7 @@ describe('TRIP CONTROLLER', () => {
           .send(testData.trip[2])
           .set('Authorization', currentToken)
           .end((error, res) => {
-            expect(res).to.have.status(422);
+            expect(res).to.have.status(400);
             expect(res.body).to.be.a('object');
             expect(res.body).to.have.property('error');
             expect(res.body.error).to.equal(errorStrings.validOrigin);
@@ -122,7 +122,7 @@ describe('TRIP CONTROLLER', () => {
           .send(testData.trip[3])
           .set('Authorization', currentToken)
           .end((error, res) => {
-            expect(res).to.have.status(422);
+            expect(res).to.have.status(400);
             expect(res.body).to.be.a('object');
             expect(res.body).to.have.property('error');
             expect(res.body.error).to.equal(errorStrings.validDestination);
@@ -136,7 +136,7 @@ describe('TRIP CONTROLLER', () => {
           .send(testData.trip[5])
           .set('Authorization', currentToken)
           .end((error, res) => {
-            expect(res).to.have.status(422);
+            expect(res).to.have.status(400);
             expect(res.body).to.be.a('object');
             expect(res.body).to.have.property('error');
             expect(res.body.error).to.equal(errorStrings.validTripDate);
@@ -150,7 +150,7 @@ describe('TRIP CONTROLLER', () => {
           .send(testData.trip[6])
           .set('Authorization', currentToken)
           .end((error, res) => {
-            expect(res).to.have.status(422);
+            expect(res).to.have.status(400);
             expect(res.body).to.be.a('object');
             expect(res.body).to.have.property('error');
             expect(res.body.error).to.equal(errorStrings.validFare);
@@ -164,7 +164,7 @@ describe('TRIP CONTROLLER', () => {
           .send(testData.trip[7])
           .set('Authorization', currentToken)
           .end((error, res) => {
-            expect(res).to.have.status(422);
+            expect(res).to.have.status(400);
             expect(res.body).to.be.a('object');
             expect(res.body).to.have.property('error');
             expect(res.body.error).to.equal(errorStrings.validFare);
@@ -206,7 +206,7 @@ describe('TRIP CONTROLLER', () => {
           .send(testData.trip[10])
           .set('Authorization', currentToken)
           .end((error, res) => {
-            expect(res).to.have.status(422);
+            expect(res).to.have.status(400);
             expect(res.body).to.be.a('object');
             expect(res.body).to.have.property('error');
             done();
@@ -363,7 +363,7 @@ describe('TRIP CONTROLLER', () => {
           .set('Authorization', currentToken)
           .send({ filter_value: '' })
           .end((error, res) => {
-            expect(res).to.have.status(422);
+            expect(res).to.have.status(400);
             expect(res.body).to.be.a('object');
             expect(res.body).to.have.property('error');
             expect(res.body.error).to.equal(errorStrings.validFilterValue);
@@ -481,7 +481,7 @@ describe('TRIP CONTROLLER', () => {
           .patch(`${tripUrl}/${tripId}`)
           .set('Authorization', currentToken)
           .end((error, res) => {
-            expect(res).to.have.status(422);
+            expect(res).to.have.status(400);
             expect(res.body).to.be.an('object');
             expect(res.body).to.have.property('error');
             expect(res.body.error).to.equal(errorStrings.validTripId);

--- a/server/tests/usersTest.js
+++ b/server/tests/usersTest.js
@@ -47,7 +47,7 @@ describe('USER CONTROLLER', () => {
           password: 'olujac1$',
         })
         .end((error, res) => {
-          expect(res).to.have.status(422);
+          expect(res).to.have.status(400);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.validName);
@@ -65,7 +65,7 @@ describe('USER CONTROLLER', () => {
           password: 'olujac1$',
         })
         .end((error, res) => {
-          expect(res).to.have.status(422);
+          expect(res).to.have.status(400);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.validName);
@@ -83,7 +83,7 @@ describe('USER CONTROLLER', () => {
           password: 'olujac1$',
         })
         .end((error, res) => {
-          expect(res).to.have.status(422);
+          expect(res).to.have.status(400);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.validEmail);
@@ -119,7 +119,7 @@ describe('USER CONTROLLER', () => {
           password: 'adann', // password length short
         })
         .end((error, res) => {
-          expect(res).to.have.status(422);
+          expect(res).to.have.status(400);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.passwordLength);
@@ -137,7 +137,7 @@ describe('USER CONTROLLER', () => {
           password: '', // empty password
         })
         .end((error, res) => {
-          expect(res).to.have.status(422);
+          expect(res).to.have.status(400);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.passwordEmpty);
@@ -178,7 +178,7 @@ describe('USER CONTROLLER', () => {
           password: 'olujac1$',
         })
         .end((error, res) => {
-          expect(res).to.have.status(422);
+          expect(res).to.have.status(400);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.validEmail);
@@ -194,7 +194,7 @@ describe('USER CONTROLLER', () => {
           password: '', // empty login password
         })
         .end((error, res) => {
-          expect(res).to.have.status(422);
+          expect(res).to.have.status(400);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('error');
           expect(res.body.error).to.equal(errorStrings.passwordEmpty);


### PR DESCRIPTION
At the moment, the endpoint allows a booking to be made
if the provided seat number is greater than bus capacity.
This will eventually lead to a situation where there are
more bookings than available seats on the bus. The provided
seat number should have a ceiling value equal to the capacity
of the bus.