### PR TITLE
[#167123513] Redesign GET /trips API endpoint

### DIFF
--- a/server/controllers/tripController.js
+++ b/server/controllers/tripController.js
@@ -54,9 +54,17 @@ class TripController {
   static async getTrips(req, res) {
     try {
       let trips = [];
-      const { filter_by } = req.query;
-      if (filter_by) {
-        trips = await tripModel.getFilteredTrips(filter_by, req.body.filter_value);
+      const { origin, destination } = req.query;
+      if (origin && destination) {
+        trips = await tripModel.getTripsByTwoColumns(['origin', 'destination'], [origin, destination]);
+        return ResponseHelper.success(res, 200, trips);
+      }
+      if (origin) {
+        trips = await tripModel.getTripsBySingleColumn('origin', origin);
+        return ResponseHelper.success(res, 200, trips);
+      }
+      if (destination) {
+        trips = await tripModel.getTripsBySingleColumn('destination', destination);
         return ResponseHelper.success(res, 200, trips);
       }
       trips = await tripModel.getTrips();

--- a/server/middleware/validateTrip.js
+++ b/server/middleware/validateTrip.js
@@ -48,18 +48,17 @@ class ValidateTrip {
  * @return {Object} error
  */
   static validateGetTrip(request, response, next) {
-    const { filter_by } = request.query;
-    if (!filter_by) {
+    const { origin, destination } = request.query;
+    if (!origin && !destination) {
       return next();
     }
-    if (filter_by !== 'origin' && filter_by !== 'destination') {
-      return responseHelper.error(response, 404, errorStrings.pageNotFound);
-    }
     const data = {
-      filter_value: request.body.filter_value,
+      origin,
+      destination,
     };
     const getTripSchema = Joi.object().keys({
-      filter_value: Joi.string().required(),
+      origin: Joi.string().min(3),
+      destination: Joi.string().min(3),
     });
 
     const error = Validator.validateJoi(data, getTripSchema);

--- a/server/model/tripModel.js
+++ b/server/model/tripModel.js
@@ -48,13 +48,28 @@ class TripModel extends Model {
   }
 
   /**
-     * Get filtered trips
+     * Get filtered trips by a single column
      * @returns {object} an object with all trips
      */
 
-  async getFilteredTrips(filter_by, filter_value) {
+  async getTripsBySingleColumn(column, value) {
     try {
-      const { rows } = await this.selectWhere('*', `LOWER(${filter_by}) LIKE LOWER('%${filter_value}%')`);
+      const { rows } = await this.selectWhere('*', `LOWER(${column}) LIKE LOWER('%${value}%')`);
+      return rows;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
+     * Get filtered trips by two columns
+     * @returns {object} an object with all trips
+     */
+
+  async getTripsByTwoColumns(column, value) {
+    try {
+      const { rows } = await this.selectWhere('*',
+        `LOWER(${column[0]}) LIKE LOWER('%${value[0]}%') and LOWER(${column[1]}) LIKE LOWER('%${value[1]}%')`);
       return rows;
     } catch (error) {
       throw error;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -30,8 +30,6 @@ const routes = (app) => {
   app.get(`${api}/bookings`, Auth.authenticateUser, BookingController.getBookings);
   app.get(`${api}/bookings/:tripId/availableSeats`, Auth.authenticateUser, ValidateBooking.validateAvailableSeats, BookingController.getAvailableSeats);
   app.get(`${api}/trips`, Auth.authenticateUser, ValidateTrip.validateGetTrip, TripController.getTrips);
-  app.get(`${api}/trips?filter_by=origin`, Auth.authenticateUser, ValidateTrip.validateGetTrip, TripController.getTrips);
-  app.get(`${api}/trips?filter_by=destination`, Auth.authenticateUser, ValidateTrip.validateGetTrip, TripController.getTrips);
   app.patch(`${api}/trips/:tripId`, Auth.authenticateAdmin, ValidateTrip.validateCancelTrip, TripController.cancelTrip);
   app.delete(`${api}/bookings/:bookingId`, Auth.authenticateUser, ValidateBooking.validateDeleteBooking, BookingController.deleteBooking);
   app.get('/', (req, res) => ResponseHelper.success(res, 200, {

--- a/server/tests/tripTest.js
+++ b/server/tests/tripTest.js
@@ -286,11 +286,10 @@ describe('TRIP CONTROLLER', () => {
           });
       });
 
-      it('It should get all filtered trips by origin', (done) => {
+      it('It should get filtered trips by origin', (done) => {
         chai.request(app)
-          .get(`${tripUrl}?filter_by=origin`)
+          .get(`${tripUrl}?origin=Lagos`)
           .set('Authorization', currentToken)
-          .send({ filter_value: 'Lagos' })
           .end((error, res) => {
             expect(res).to.have.status(200);
             expect(res.body).to.be.a('object');
@@ -308,11 +307,31 @@ describe('TRIP CONTROLLER', () => {
           });
       });
 
-      it('It should get all filtered trips by destination', (done) => {
+      it('It should get filtered trips by destination', (done) => {
         chai.request(app)
-          .get(`${tripUrl}?filter_by=destination`)
+          .get(`${tripUrl}?destination=Abuja`)
           .set('Authorization', currentToken)
-          .send({ filter_value: 'Abuja' })
+          .end((error, res) => {
+            expect(res).to.have.status(200);
+            expect(res.body).to.be.a('object');
+            expect(res.body).to.have.property('data');
+            expect(res.body.data).to.be.a('array');
+            expect(res.body.data[0]).to.be.a('object');
+            expect(res.body.data[0]).to.have.property('id');
+            expect(res.body.data[0]).to.have.property('bus_id');
+            expect(res.body.data[0]).to.have.property('origin');
+            expect(res.body.data[0]).to.have.property('destination');
+            expect(res.body.data[0]).to.have.property('trip_date');
+            expect(res.body.data[0]).to.have.property('fare');
+            expect(res.body.data[0]).to.have.property('status');
+            done();
+          });
+      });
+
+      it('It should get filtered trips by origin and destination', (done) => {
+        chai.request(app)
+          .get(`${tripUrl}?origin=Ikeja&destination=CMS`)
+          .set('Authorization', currentToken)
           .end((error, res) => {
             expect(res).to.have.status(200);
             expect(res.body).to.be.a('object');
@@ -331,9 +350,8 @@ describe('TRIP CONTROLLER', () => {
       });
       it('it should return empty data if query not matched any row', (done) => {
         chai.request(app)
-          .get(`${tripUrl}?filter_by=origin`)
+          .get(`${tripUrl}?origin=Maiduguri`)
           .set('Authorization', currentToken)
-          .send({ filter_value: 'Maiduguri' })
           .end((error, res) => {
             expect(res).to.have.status(200);
             expect(res.body).to.be.a('object');
@@ -344,29 +362,51 @@ describe('TRIP CONTROLLER', () => {
             done();
           });
       });
-      it('it should not get trips if url is not a valid query', (done) => {
+      it('it should not get filtered trips if origin is less than 3 characters', (done) => {
         chai.request(app)
-          .get(`${tripUrl}?filter_by=original`)
+          .get(`${tripUrl}?origin=Ma`)
           .set('Authorization', currentToken)
-          .send({ filter_value: 'Maiduguri' })
-          .end((error, res) => {
-            expect(res).to.have.status(404);
-            expect(res.body).to.be.an('object');
-            expect(res.body).to.have.property('error');
-            expect(res.body.error).to.equal(errorStrings.pageNotFound);
-            done();
-          });
-      });
-      it('it should not get filtered trips with empty filter value', (done) => {
-        chai.request(app)
-          .get(`${tripUrl}?filter_by=origin`)
-          .set('Authorization', currentToken)
-          .send({ filter_value: '' })
           .end((error, res) => {
             expect(res).to.have.status(400);
             expect(res.body).to.be.a('object');
             expect(res.body).to.have.property('error');
-            expect(res.body.error).to.equal(errorStrings.validFilterValue);
+            expect(res.body.error).to.equal('origin length must be at least 3 characters long');
+            done();
+          });
+      });
+      it('it should not get filtered trips if destination is less than 3 characters', (done) => {
+        chai.request(app)
+          .get(`${tripUrl}?destination=Ma`)
+          .set('Authorization', currentToken)
+          .end((error, res) => {
+            expect(res).to.have.status(400);
+            expect(res.body).to.be.a('object');
+            expect(res.body).to.have.property('error');
+            expect(res.body.error).to.equal('destination length must be at least 3 characters long');
+            done();
+          });
+      });
+      it('it should not get filtered trips if origin is empty', (done) => {
+        chai.request(app)
+          .get(`${tripUrl}?origin&destination=Lagos`)
+          .set('Authorization', currentToken)
+          .end((error, res) => {
+            expect(res).to.have.status(400);
+            expect(res.body).to.be.a('object');
+            expect(res.body).to.have.property('error');
+            expect(res.body.error).to.equal('origin is not allowed to be empty');
+            done();
+          });
+      });
+      it('it should not get filtered trips if destination is empty', (done) => {
+        chai.request(app)
+          .get(`${tripUrl}?origin=Lagos&destination`)
+          .set('Authorization', currentToken)
+          .end((error, res) => {
+            expect(res).to.have.status(400);
+            expect(res.body).to.be.a('object');
+            expect(res.body).to.have.property('error');
+            expect(res.body.error).to.equal('destination is not allowed to be empty');
             done();
           });
       });


### PR DESCRIPTION
At the moment, the endpoint allows a user to filter trips by origin
or destination but, it is not properly designed in that, Swagger
documentation disallow GET request from having a body property.

This redesign will focus on having the origin and destination as
part of the request query. For instance
GET /trips?origin=some_location&destination=some_other_location