### PR TITLE
[#167209275] Fix Bearer Authorization

### DIFF
--- a/server/config/swagger.js
+++ b/server/config/swagger.js
@@ -15,8 +15,7 @@ const swaggerDefinition = {
       url: 'https://opensource.org/licenses/MIT',
     },
   },
-  // host: 'way-farer-shonubi.herokuapp.com', // the host or url of the app
-  host: 'localhost:8300', // the host or url of the app
+  host: 'way-farer-shonubi.herokuapp.com', // the host or url of the app
   basePath: '/api/v1', // the basepath of your endpoint
   tags: [{
     name: 'auth',

--- a/server/middleware/Auth.js
+++ b/server/middleware/Auth.js
@@ -23,7 +23,10 @@ class Auth {
 
   static authenticateUser(request, response, next) {
     try {
-      const token = request.headers.authorization;
+      let token = request.headers.authorization;
+      if (token && token.startsWith('Bearer ')) {
+        token = token.slice(7, token.length);
+      }
       request.user = Auth.verifyToken(token);
       return next();
     } catch (error) {
@@ -43,7 +46,10 @@ class Auth {
  */
   static authenticateAdmin(request, response, next) {
     try {
-      const token = request.headers.authorization;
+      let token = request.headers.authorization;
+      if (token && token.startsWith('Bearer ')) {
+        token = token.slice(7, token.length);
+      }
       request.user = Auth.verifyToken(token);
       if (request.user.is_admin === false) {
         return ResponseHelper.error(response, 403, errorStrings.notAllowed);


### PR DESCRIPTION
At the moment, the Authorization class does not handle the
Bearer prefix of Authorization credentials. This is not in
line with OAuth 2.0 standards.