### PR TITLE
[#167417927] Fix signup endpoint validation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ e.g npm test
 
 <tr><td>POST</td> <td>/api/v1/auth/signup</td>  <td>User signup</td></tr>
 
-<tr><td>POST</td> <td>/api/v1/auth/login</td>  <td>User signin</td></tr>
+<tr><td>POST</td> <td>/api/v1/auth/signin</td>  <td>User signin</td></tr>
 
 <tr><td>POST</td> <td>/api/v1/trips</td>  <td>Create a trip</td></tr>
 

--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -59,8 +59,7 @@ class UsersController {
       const userData = UsersController.createUserObject(signInResult);
       return ResponseHelper.success(res, 200, userData);
     } catch (error) {
-      // return ResponseHelper.error(res, 500, errorStrings.serverError);
-      return ResponseHelper.error(res, 500, error.message);
+      return ResponseHelper.error(res, 500, errorStrings.serverError);
     }
   }
 

--- a/server/helpers/errorStrings.js
+++ b/server/helpers/errorStrings.js
@@ -10,7 +10,7 @@ const errorStrings = {
   passwordEmpty: 'password is not allowed to be empty',
   passwordLength: 'password length must be at least 8 characters long',
   emailExists: 'Email address has already been registered',
-  validName: 'Name field cannot be empty and must be only letters',
+  validName: 'field cannot be empty and must be only letters',
   validEmail: 'email must be a valid email',
   loginFailure: 'Could not login. Email and password do not match',
   validBusId: 'Enter a valid bus id',

--- a/server/middleware/ValidateUser.js
+++ b/server/middleware/ValidateUser.js
@@ -24,13 +24,13 @@ class ValidateUser {
    * @return {Object} error
    */
   static validateSignupFormData(request, response, next) {
-    const name = Joi.string().regex(rules.validName).required().error(new Error(errorStrings.validName));
+    const name = Joi.string().regex(rules.validName).required();
     const password = Joi.string().min(8).required().strict();
     const email = Joi.string().email().lowercase().required();
 
     const createSignUpSchema = Joi.object().keys({
-      first_name: name,
-      last_name: name,
+      first_name: name.error(new Error(`first_name ${errorStrings.validName}`)),
+      last_name: name.error(new Error(`last_name ${errorStrings.validName}`)),
       password,
       email,
     });

--- a/server/tests/usersTest.js
+++ b/server/tests/usersTest.js
@@ -50,7 +50,7 @@ describe('USER CONTROLLER', () => {
           expect(res).to.have.status(400);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('error');
-          expect(res.body.error).to.equal(errorStrings.validName);
+          expect(res.body.error).to.equal(`first_name ${errorStrings.validName}`);
           done();
         });
     });
@@ -68,7 +68,7 @@ describe('USER CONTROLLER', () => {
           expect(res).to.have.status(400);
           expect(res.body).to.be.an('object');
           expect(res.body).to.have.property('error');
-          expect(res.body.error).to.equal(errorStrings.validName);
+          expect(res.body.error).to.equal(`last_name ${errorStrings.validName}`);
           done();
         });
     });


### PR DESCRIPTION
At the moment, the first_name and the last_name fields show the same
validation message
`Name field cannot be empty and must be only letters`
The error message shown should be peculiar to a particular field.
For example, it should be something like
`first_name field cannot be empty and must be only letters`